### PR TITLE
adds one-shot benchmark for `compile_bdd` on select CNFs

### DIFF
--- a/examples/one_shot_benchmark.rs
+++ b/examples/one_shot_benchmark.rs
@@ -1,0 +1,42 @@
+extern crate criterion;
+extern crate rsdd;
+
+use criterion::black_box;
+use rsdd::{manager::rsbdd_manager::BddManager, repr::cnf::Cnf};
+use std::time::{Instant, Duration};
+
+fn compile_bdd(str: String) -> () {
+  let cnf = Cnf::from_file(str);
+  let mut man = BddManager::new_default_order(cnf.num_vars());
+  man.from_cnf(&cnf);
+}
+
+fn bench_cnf_bdd(cnf_str: String) -> Duration {
+  let start = Instant::now();
+  compile_bdd(black_box(cnf_str));
+  start.elapsed()
+}
+
+fn main() {
+  let cnf_strs = vec![
+    ("bench-01", String::from(include_str!("../cnf/bench-01.cnf"))),
+    ("bench-02", String::from(include_str!("../cnf/bench-02.cnf"))),
+    ("bench-03", String::from(include_str!("../cnf/bench-03.cnf"))),
+    // ("c8-easier", String::from(include_str!("../cnf/c8-easier.cnf"))),
+    ("c8-very-easy", String::from(include_str!("../cnf/c8-very-easy.cnf"))),
+    // ("c8", String::from(include_str!("../cnf/c8.cnf"))),
+    // ("count", String::from(include_str!("../cnf/count.cnf"))),
+    ("s298", String::from(include_str!("../cnf/s298.cnf"))),
+    // ("s344", String::from(include_str!("../cnf/s344.cnf"))),
+    // ("s444", String::from(include_str!("../cnf/s444.cnf"))),
+    // ("s510", String::from(include_str!("../cnf/s510.cnf"))),
+    // ("s641", String::from(include_str!("../cnf/s641.cnf"))),
+    // ("unsat-1", String::from(include_str!("../cnf/unsat-1.cnf"))),
+  ];
+
+  for (cnf_name, cnf_str) in cnf_strs {
+    let d = bench_cnf_bdd(cnf_str);
+    let c8_time = d.as_secs_f64();
+    println!("one-shot compile_bdd time for {}: {}s", cnf_name, c8_time);
+  }
+}


### PR DESCRIPTION
This PR is a PoC for a Rust-native one-shot benchmark for `compile_bdd`, based off of the CNFs in `cnf/`. It is very simple - just using in-built Rust timing metrics - which makes me a bit embarrassed to say that it took this long to figure out!

For now, I've only selected the CNFs that run quickly on my computer, but this should work for a variety of different CNFs.

Example usage (runs as an example, and using the `--release` flag for optimized code):

```sh
$ cargo run --example one_shot_benchmark --release
   Compiling rsdd v0.1.0 (/Users/matt/code/rsdd)
    Finished release [optimized + debuginfo] target(s) in 1.53s
     Running `target/release/examples/one_shot_benchmark`
one-shot compile_bdd time for bench-01: 0.003758554s
one-shot compile_bdd time for bench-02: 0.007862176s
one-shot compile_bdd time for bench-03: 0.007073939s
one-shot compile_bdd time for c8-very-easy: 60.634946855s
one-shot compile_bdd time for s298: 3.103544092s
```

If we think this is a good approach, I can extend by:
- outputting this in an interchangeable format (JSON, CSV), tagged by git commit hash or date. this lets us track it over time. I'm open to suggestions on what makes the most sense
- selectively running different sets of benchmarks based on approximate size ("small" benchmarks, "medium", "long", etc.); we can run cheap benchmarks multiple times, if that's helpful
- additional diagnostic information (ex the recursive calls and cache evictions you mentioned)
- adding some sort of progress bar if we feel that it would be helpful

## stuff that didn't work

I did a bit of digging and tried a few approaches; want to write them down for future's sake.

* running it with the "standard" way with two `[[bench]]` targets, a `#[bench]` attribute ,and placing the file in `benches` does require the `#![feature(test)]` flag (and exposing the `test` crate), which brings us out of stable - this seems risky
* using the [`bencher`](https://docs.rs/bencher/0.1.5/bencher/) crate doesn't work since there is no consistent way to control the number of iterations; there is a [`bench_n`](https://docs.rs/bencher/0.1.5/bencher/struct.Bencher.html#method.bench_n) function, but it's not well-documented and my attempt in using it did not work.
* as of now, there is an open issue in criterion to add this, but work has not been taken up there; ex https://github.com/bheisler/criterion.rs/issues/557