### PR TITLE
Prototyping "modified" canoncalize logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,6 @@ path = "bin/one_shot_benchmark.rs"
 name = "bayesian_network_compiler"
 path = "bin/bayesian_network_compiler.rs"
 
+[[bin]]
+name = "compare_canonicalize"
+path = "bin/compare_canonicalize.rs"

--- a/bin/compare_canonicalize.rs
+++ b/bin/compare_canonicalize.rs
@@ -137,22 +137,21 @@ fn main(){
   let dtree = build_dtree(&cnf);
 
   let mut originals: Vec<f64> = Vec::new();
+  let mut modifieds: Vec<f64> = Vec::new();
+
+  // TODO(mattxwang): can we add some sort of equality check here?
+  // perhaps evaluate the same WMC on both trees with unsmoothed_wmc,
+  // or maybe eval_sdd? not sure
   for _ in 0..args.iterations{
     originals.push(compile_sdd_benchmark(black_box(&cnf), dtree.to_vtree().unwrap(), false).as_secs_f64());
+    modifieds.push(compile_sdd_benchmark(black_box(&cnf), dtree.to_vtree().unwrap(), true).as_secs_f64());
   }
 
   let originals_sum: f64 = originals.iter().sum();
   let og_time = originals_sum / args.iterations as f64;
 
-  let mut modifieds: Vec<f64> = Vec::new();
-  for _ in 0..args.iterations{
-    modifieds.push(compile_sdd_benchmark(black_box(&cnf), dtree.to_vtree().unwrap(), true).as_secs_f64());
-  }
-
   let modifieds_sum: f64 = modifieds.iter().sum();
   let md_time = modifieds_sum / args.iterations as f64;
-
-
 
   println!("
 Avg original time: {:?}s

--- a/bin/compare_canonicalize.rs
+++ b/bin/compare_canonicalize.rs
@@ -1,0 +1,163 @@
+extern crate criterion;
+extern crate rsdd;
+extern crate rsgm;
+
+use clap::Parser;
+use criterion::black_box;
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use rsdd::{
+  repr::{
+    cnf::Cnf,
+    var_label::{Literal, VarLabel}
+  },
+  builder::{
+    var_order::VarOrder,
+    sdd_builder,
+    dtree::DTree,
+    repr::builder_sdd::VTree
+  },
+};
+use rsgm::bayesian_network::BayesianNetwork;
+
+/// Test driver for comparing canonicalize implementations
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    /// An input Bayesian network file in JSON format
+    #[clap(short, long, value_parser)]
+    file: String,
+
+
+    /// Number of iterations to compare against, for both types
+    #[clap(short, long, value_parser, default_value_t = 4)]
+    iterations: u32,
+}
+
+/// construct a CNF for the two TERMS (i.e., conjunctions of literals) t1 => t2
+fn implies(t1: &Vec<Literal>, t2: &Vec<Literal>) -> Vec<Vec<Literal>> {
+  let mut r : Vec<Vec<Literal>> = Vec::new();
+  // negate the lhs
+  let lhs : Vec<Literal> = t1.iter().map(|l| Literal::new(l.get_label(), !l.get_polarity())).collect();
+  for v in t2.iter() {
+      let mut new_clause = lhs.clone();
+      new_clause.push(v.clone());
+      r.push(new_clause);
+  }
+  r
+}
+
+/// constructs a CNF constraint where exactly one of `lits` is true
+fn exactly_one(lits: Vec<Literal>) -> Vec<Vec<Literal>> {
+  let mut r : Vec<Vec<Literal>> = Vec::new();
+  // one must be true
+  r.push(lits.clone());
+  // pairwise constraints
+  for x in 0..(lits.len()) {
+      for y in (x+1)..(lits.len()) {
+          r.push(vec![lits[x].negated(), lits[y].negated()]);
+      }
+  }
+  r
+}
+
+/// Produce a Chavira-Darwiche encoding of a Bayesian network
+fn bn_to_cnf(network: &BayesianNetwork) -> Cnf {
+  let mut clauses : Vec<Vec<Literal>> = Vec::new();
+  let mut var_count = 0;
+
+  // create one indicator for every variable assignment
+  // maps Variable Name -> (Variable Assignment -> Label)
+  let mut indicators : HashMap<String, HashMap<String, VarLabel>> = HashMap::new();
+
+  for v in network.topological_sort() {
+      // create this variable's indicators and parameter clauses
+      let mut cur_indic : Vec<Literal> = Vec::new();
+      indicators.insert(v.clone(), HashMap::new());
+      for varassgn in network.get_all_assignments(&v) {
+          let cur_var = VarLabel::new_usize(var_count);
+          cur_indic.push(Literal::new(cur_var, true));
+          indicators.get_mut(&v).unwrap().insert(varassgn.clone(), cur_var);
+          var_count += 1;
+
+          for passgn in network.parent_assignments(&v) {
+              let cur_param = VarLabel::new_usize(var_count);
+              var_count += 1;
+
+              // build cur_param => cur_assgn /\ cur_indic
+              let indic_vec : Vec<Literal> = passgn.iter().map(|(varname, varval)| {
+                  let varlabel = indicators[varname][varval];
+                  Literal::new(varlabel, true)
+              }).collect();
+
+              let mut imp1 = implies(&vec![Literal::new(cur_param, true)], &indic_vec);
+              let mut imp2 = implies(&indic_vec, &vec![Literal::new(cur_param, false)]);
+              clauses.append(&mut imp1);
+              clauses.append(&mut imp2);
+          }
+      }
+      // build exactly-one for indicator clause
+      let mut exactly1 = exactly_one(cur_indic);
+      clauses.append(&mut exactly1);
+  }
+  Cnf::new(clauses)
+}
+
+fn build_dtree(cnf: &Cnf) -> DTree {
+  let start = Instant::now();
+  let dtree = DTree::from_cnf(&cnf, &VarOrder::linear_order(cnf.num_vars()));
+  let duration = start.elapsed();
+  println!("Dtree built\nNumber of variables: {}\n\tNumber of clauses: {}\n\tWidth: {}\n\tElapsed dtree time: {:?}",
+        cnf.num_vars(), cnf.clauses().len(), dtree.width(), duration);
+  dtree
+}
+
+fn compile_sdd_benchmark(cnf: &Cnf, vtree: VTree, modified: bool) -> Duration {
+  let mut compiler = sdd_builder::SddManager::new(vtree);
+  compiler.set_canonicalize(modified);
+
+  let start = Instant::now();
+  compiler.from_cnf(&cnf);
+  // let r = compiler.from_cnf(&cnf);
+  let duration = start.elapsed();
+  // let sz = compiler.count_nodes(r);
+
+  duration
+}
+
+fn main(){
+  let args = Args::parse();
+
+  let bn = BayesianNetwork::from_string(std::fs::read_to_string(args.file).unwrap().as_str());
+
+  let cnf = bn_to_cnf(&bn);
+
+  let dtree = build_dtree(&cnf);
+
+  let mut originals: Vec<f64> = Vec::new();
+  for _ in 0..args.iterations{
+    originals.push(compile_sdd_benchmark(black_box(&cnf), dtree.to_vtree().unwrap(), false).as_secs_f64());
+  }
+
+  let originals_sum: f64 = originals.iter().sum();
+  let og_time = originals_sum / args.iterations as f64;
+
+  let mut modifieds: Vec<f64> = Vec::new();
+  for _ in 0..args.iterations{
+    modifieds.push(compile_sdd_benchmark(black_box(&cnf), dtree.to_vtree().unwrap(), true).as_secs_f64());
+  }
+
+  let modifieds_sum: f64 = modifieds.iter().sum();
+  let md_time = modifieds_sum / args.iterations as f64;
+
+
+
+  println!("
+Avg original time: {:?}s
+Avg modified time: {:?}s
+Avg ratio (od/mg): {:?}
+  ",
+  og_time, md_time, og_time/md_time)
+}

--- a/src/builder/sdd_builder.rs
+++ b/src/builder/sdd_builder.rs
@@ -648,9 +648,9 @@ impl<'a> SddManager {
 
 
     pub fn sdd_eq(&self, a: SddPtr, b: SddPtr) -> bool {
-        if self.modified_canonicalize {
-            return (self.wmc_hash::<u32>(a) - self.wmc_hash::<u32>(b)) < 1
-        }
+        // if self.modified_canonicalize {
+        //     return (self.wmc_hash::<u32>(a) - self.wmc_hash::<u32>(b)) < 1
+        // }
         a == b
     }
 

--- a/src/builder/sdd_builder.rs
+++ b/src/builder/sdd_builder.rs
@@ -106,6 +106,8 @@ pub struct SddManager {
     stats: SddStats,
     /// the apply cache
     app_cache: Vec<Lru<(SddPtr, SddPtr), SddPtr>>,
+    // experimenting with different canonicalize options
+    modified_canonicalize: bool,
 }
 
 impl<'a> SddManager {
@@ -120,9 +122,14 @@ impl<'a> SddManager {
             stats: SddStats::new(),
             vtree: VTreeManager::new(vtree),
             app_cache,
+            modified_canonicalize: false,
         };
 
         return m;
+    }
+
+    pub fn set_canonicalize(&mut self, b: bool) -> () {
+        self.modified_canonicalize = b
     }
 
     // Walks the Sdd, caching results of previously computed values
@@ -237,8 +244,10 @@ impl<'a> SddManager {
 
     /// Returns a canonicalized SDD pointer from a list of (prime, sub) pairs
     fn canonicalize(&mut self, mut node: Vec<(SddPtr, SddPtr)>, table: VTreeIndex) -> SddPtr {
-        // first compress
-        self.compress(&mut node);
+        if !self.modified_canonicalize {
+            // first compress
+            self.compress(&mut node);
+        }
         // check for a base case
         if node.len() == 0 {
             return SddPtr::new_const(true);

--- a/src/builder/sdd_builder.rs
+++ b/src/builder/sdd_builder.rs
@@ -108,6 +108,9 @@ pub struct SddManager {
     app_cache: Vec<Lru<(SddPtr, SddPtr), SddPtr>>,
     // experimenting with different canonicalize options
     modified_canonicalize: bool,
+    // base prime number for wmc-based hashing
+    wmc_base: u64, // TODO(mattxwang): should we use a different bignum-esque impl here?
+    wmc_map: SddWmc<u64>, // TODO(mattxwang): make this more generic?
 }
 
 impl<'a> SddManager {
@@ -117,12 +120,17 @@ impl<'a> SddManager {
             app_cache.push(Lru::new(8));
         }
 
+        let vtree_clone = vtree.clone();
+
         let m = SddManager {
             tbl: SddTable::new(&vtree),
             stats: SddStats::new(),
             vtree: VTreeManager::new(vtree),
             app_cache,
             modified_canonicalize: false,
+            wmc_base: 122959073, // TODO(mattxwang): make this user-configurable
+            // TODO(mattxwang): many things wrong here, incl. template types
+            wmc_map: SddWmc::new(0, 122959073, vtree_clone),
         };
 
         return m;
@@ -222,10 +230,21 @@ impl<'a> SddManager {
         self.tbl.bdd_man_mut(f.vtree().value())
     }
 
+    // TODO: make this more generic
+    // fn wmc_hash<T: Num + Clone + Debug + Copy>(&mut self, sdd: SddPtr) -> T
+    fn wmc_hash<T: Num + Clone + Debug + Copy>(&self, sdd: SddPtr) -> u64 {
+        // This doesn't work :( mutability issue on unsmoothed_wmc. need to make wmc immutable?
+        // self.unsmoothed_wmc::<u64>(sdd, &self.wmc_map) % self.wmc_base
+        1 % &self.wmc_base
+    }
 
     /// Canonicalizes the list of (prime, sub) terms in-place
     /// `node`: a list of (prime, sub) pairs
     fn compress(&mut self, node: &mut Vec<(SddPtr, SddPtr)>) -> () {
+        if self.modified_canonicalize {
+            panic!("compress called within modified version")
+        }
+
         let mut i = 0;
         for i in 0..node.len() {
             // see if we can compress i
@@ -629,6 +648,9 @@ impl<'a> SddManager {
 
 
     pub fn sdd_eq(&self, a: SddPtr, b: SddPtr) -> bool {
+        if self.modified_canonicalize {
+            return (self.wmc_hash::<u32>(a) - self.wmc_hash::<u32>(b)) < 1
+        }
         a == b
     }
 


### PR DESCRIPTION
This PR (so far) implements:

- a toggle within `SddManager` to use a "different"/modified canonicalize function, with an internal state variable
- a benchmark to compare the current `SddManager` with the modified `SddManager`
- (just for demonstration purposes) disabling compression in the modified canonicalize to induce a performance loss

Additionally, it adds some commented code / skeleton information for a WMC-based approach, though it doesn't work right now.

You can run it with:

```console
$ cargo run --bin compare_canonicalize -- --file bayesian_networks/cancer.json   
Dtree built
Number of variables: 30
	Number of clauses: 54
	Width: 5
	Elapsed dtree time: 784.708µs
Avg original time: 0.017067838249999998s
Avg modified time: 0.61624865625s
Avg ratio (od/mg): 0.02769634964214171
```

Note that the original `SddManager` significantly outperforms the modified version, as expected!